### PR TITLE
Fix proptypes warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "raf": "^3.2.0"
   },
   "peerDependencies": {

--- a/src/AnimatedNumber.jsx
+++ b/src/AnimatedNumber.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import raf from 'raf';
 
 const ANIMATION_DURATION: number = 300;


### PR DESCRIPTION
Fixes warnings caused by using propTypes directly instead of with the new package.