### PR TITLE
changing to getDerivedStateFromProps

### DIFF
--- a/src/AnimatedNumber.jsx
+++ b/src/AnimatedNumber.jsx
@@ -60,17 +60,17 @@ export default class AnimatedNumber extends Component {
         this.prepareTween(this.props);
     }
 
-    componentWillReceiveProps(nextProps: AnimatedNumberProps) {
+    static getDerivedStateFromProps(props: AnimatedNumberProps, state) {
 
-        if (this.state.currentValue === nextProps.value) {
-            return;
-        }
+        if (state.currentValue === props.value) {
+                return;
+            }
 
-        if (this.tweenHandle) {
-            this.endTween();
-        }
+            if (this.tweenHandle) {
+                this.endTween();
+            }
 
-        this.prepareTween(nextProps);
+            this.prepareTween(nextProps);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
componentWillReceiveProps  has been renamed, it causes a warning that we should rename it to UNSAFE_componentWillReceiveProps  or use getDerivedStateFromProps instead... more here: 
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html